### PR TITLE
[webgpu] Calculating coords use i32 to avoid precision issue

### DIFF
--- a/tfjs-backend-webgpu/src/kernels/precision_webgpu_test.ts
+++ b/tfjs-backend-webgpu/src/kernels/precision_webgpu_test.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as tf from '@tensorflow/tfjs-core';
+import {test_util} from '@tensorflow/tfjs-core';
+import {describeWebGPU} from '../test_util';
+
+const expectArraysClose = test_util.expectArraysClose;
+
+describeWebGPU('precision', () => {
+  it('float precision', async () => {
+    const batch = 262145;
+    const size = batch * 4 * 4 * 4;
+
+    const aData = new Float32Array(size);
+    const bData = new Float32Array(size / 4);
+    for (let i = 0; i < size; i++) {
+      aData[i] = i - 100;
+      if (i % 4 === 0) {
+        const iB = i / 4;
+        bData[iB] = iB - 100;
+      }
+    }
+
+    const aTensor = tf.tensor4d(aData, [batch, 4, 4, 4]);
+    const bTensor = tf.tensor4d(bData, [batch, 4, 4, 1]);
+
+    const gpuData = await tf.add(aTensor, bTensor).data();
+    const expected = [
+      20971312, 20971312, 20971316, 20971316, 20971316, 20971318, 20971320,
+      20971320, 20971322, 20971324, 20971324, 20971326, 20971328, 20971328,
+      20971330, 20971332, 20971332, 20971332, 20971336, 20971336
+    ];
+    expectArraysClose(Array.from(gpuData).slice(16777210, 16777230), expected);
+  });
+});

--- a/tfjs-backend-webgpu/src/shader_preprocessor.ts
+++ b/tfjs-backend-webgpu/src/shader_preprocessor.ts
@@ -244,6 +244,30 @@ const SHADER_PREFIX = `
     return res;
   }
 
+  fn dotVec2I32(a : vec2<i32>, b : vec2<i32>) -> i32 {
+    var dotResult = 0;
+    for (var i = 0; i < 2; i = i + 1) {
+      dotResult = dotResult + a[i]*b[i];
+    }
+    return dotResult;
+  }
+
+  fn dotVec3I32(a : vec3<i32>, b : vec3<i32>) -> i32 {
+    var dotResult = 0;
+    for (var i = 0; i < 3; i = i + 1) {
+      dotResult = dotResult + a[i]*b[i];
+    }
+    return dotResult;
+  }
+
+  fn dotVec4I32(a : vec4<i32>, b : vec4<i32>) -> i32 {
+    var dotResult = 0;
+    for (var i = 0; i < 4; i = i + 1) {
+      dotResult = dotResult + a[i]*b[i];
+    }
+    return dotResult;
+  }
+
   // Checks whether coordinates lie within the bounds of the shape.
   fn coordsInBounds4D(coord : vec4<i32>, shape : vec4<i32>) -> bool {
     return all(coord >= vec4<i32>(0)) &&
@@ -266,16 +290,16 @@ const SAMPLING_SNIPPETS = `
   }
 
   fn getFlatIndex2D(coords : vec2<i32>, shape : vec2<i32>) -> i32 {
-    return i32(dot(vec2<f32>(coords), vec2<f32>(f32(shape.y), 1.0)));
+    return dotVec2I32(coords, vec2<i32>(shape.y, 1));
   }
 
   fn getFlatIndex3D(coords : vec3<i32>, shape : vec3<i32>) -> i32 {
-    return i32(dot(vec3<f32>(coords), vec3<f32>(f32(shape.y) * f32(shape.z), f32(shape.z), 1.0)));
+    return dotVec3I32(coords, vec3<i32>(shape.y * shape.z, shape.z, 1));
   }
 
   fn getFlatIndex4D(coords : vec4<i32>, shape : vec4<i32>) -> i32 {
-    return i32(dot(vec4<f32>(coords), vec4<f32>(
-        f32(shape.y) * f32(shape.z) * f32(shape.w), f32(shape.z) * f32(shape.w), f32(shape.w), 1.0)));
+    return dotVec4I32(coords, vec4<i32>(
+        shape.y * shape.z * shape.w, shape.z * shape.w, shape.w, 1));
   }
 
   // Only used when the y/z dimension of workgroup size is 1.
@@ -308,22 +332,22 @@ function getOutputFlatIndexSnippet(outRank: number) {
     case 2:
       snippet += `
         fn getOutputFlatIndex(coords : vec2<i32>) -> i32 {
-          return i32(dot(vec2<f32>(coords), vec2<f32>(f32(uniforms.outShapeStrides), 1.0)));
+          return dotVec2I32(coords, vec2<i32>(uniforms.outShapeStrides, 1));
         }
         `;
       break;
     case 3:
       snippet += `
         fn getOutputFlatIndex(coords : vec3<i32>) -> i32 {
-          return i32(dot(vec3<f32>(coords), vec3<f32>(f32(uniforms.outShapeStrides.x), f32(uniforms.outShapeStrides.y), 1.0)));
+          return dotVec3I32(coords, vec3<i32>(uniforms.outShapeStrides.x, uniforms.outShapeStrides.y, 1));
         }
         `;
       break;
     case 4:
       snippet += `
         fn getOutputFlatIndex(coords : vec4<i32>) -> i32 {
-          return i32(dot(vec4<f32>(coords), vec4<f32>(
-            f32(uniforms.outShapeStrides.x), f32(uniforms.outShapeStrides.y), f32(uniforms.outShapeStrides.z), 1.0)));
+          return dotVec4I32(coords, vec4<i32>(
+            uniforms.outShapeStrides.x, uniforms.outShapeStrides.y, uniforms.outShapeStrides.z, 1));
         }
         `;
       break;


### PR DESCRIPTION
Currently dot only supports vecN<f32> as input (https://github.com/gpuweb/gpuweb/issues/2231).

For general cases, we can cast i32 to f32. However, when calculating coords, if the coords is too big,
cast may result in precission issue.

This also fix conformance fail of model benchmark=posenet&inputSize=1024&architecture=ResNet50.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.